### PR TITLE
Fix issue 9 - Span timeline not compatible with Safari

### DIFF
--- a/src/components/TracePage/TraceTimelineViewer/index.js
+++ b/src/components/TracePage/TraceTimelineViewer/index.js
@@ -198,10 +198,8 @@ TimelineRow.Left.propTypes = {
 TimelineRow.Right = props => {
   const { children, ...rest } = props;
   return (
-    <div className="col-xs-9" {...rest}>
-      <div className="relative" style={{ height: '100%' }}>
-        {children}
-      </div>
+    <div className="col-xs-9 relative" {...rest}>
+      {children}
     </div>
   );
 };


### PR DESCRIPTION
Resolves the issue with the span timeline view in Safari.

Edited UI view in Chrome and Safari are attached.

Chrome:
![jaeger_ui_issue_9_chrome](https://cloud.githubusercontent.com/assets/2304337/25881253/e04b5e4e-3509-11e7-809c-946af0371d99.png)

Safari:
![jaeger_ui_issue_9_safari](https://cloud.githubusercontent.com/assets/2304337/25881254/e04b92ba-3509-11e7-9da2-261a168464e6.png)



