### PR TITLE
Fix #5 - Note number of erred spans in trace search results

### DIFF
--- a/src/components/SearchTracePage/TraceSearchResult.css
+++ b/src/components/SearchTracePage/TraceSearchResult.css
@@ -5,3 +5,13 @@
 .trace-search-result:hover .ui.header.trace-search-result--duration {
   color: #00474E;
 }
+
+.trace-search-result--spans {
+	display: inline-block;
+	margin-right: 0.5em;
+}
+
+.trace-search-result--erred-spans {
+	color: #c00;
+	display: inline-block;
+}

--- a/src/components/SearchTracePage/TraceSearchResult.js
+++ b/src/components/SearchTracePage/TraceSearchResult.js
@@ -32,7 +32,14 @@ const getBackgroundStyle = durationPercent =>
   90deg, rgba(17, 147, 154, .3) ${durationPercent}%, whitesmoke ${durationPercent - 100}%)`;
 
 export default function TraceSearchResult({ trace, durationPercent = 100 }) {
-  const { duration, services, timestamp, numberOfSpans, traceName } = trace;
+  const {
+    duration,
+    services,
+    timestamp,
+    numberOfErredSpans,
+    numberOfSpans,
+    traceName,
+  } = trace;
   return (
     <div
       className="trace-search-result"
@@ -53,12 +60,18 @@ export default function TraceSearchResult({ trace, durationPercent = 100 }) {
       </div>
       <div className="p1">
         <div className="clearfix">
-          <div className="trace-search-result--spans col col-2">
-            {numberOfSpans} span{numberOfSpans > 1 && 's'}
+          <div className="col col-2">
+            <span className="trace-search-result--spans">
+              {numberOfSpans} span{numberOfSpans > 1 && 's'}
+            </span>
+            {numberOfErredSpans &&
+              <span className="trace-search-result--erred-spans">
+                {numberOfErredSpans} error{numberOfErredSpans > 1 && 's'}
+              </span>}
           </div>
           <div className="col col-6">
             {sortBy(services, s => s.name).map(service => (
-              <div className="inline-block mr1 mb1">
+              <div key={service.name} className="inline-block mr1 mb1">
                 <TraceServiceTag key={service.name} service={service} />
               </div>
             ))}

--- a/src/demo/trace-generators.js
+++ b/src/demo/trace-generators.js
@@ -106,9 +106,9 @@ export default chance.mixin({
       // very short trace
       // average case
       numberOfSpans = chance.pickone([
-        Math.ceil(chance.normal({ mean: 200, dev: 10 })),
+        Math.ceil(chance.normal({ mean: 200, dev: 10 })) + 1,
         Math.ceil(chance.integer({ min: 3, max: 10 })),
-        Math.ceil(chance.normal({ mean: 45, dev: 15 })),
+        Math.ceil(chance.normal({ mean: 45, dev: 15 })) + 1,
       ]),
       numberOfProcesses = chance.integer({ min: 1, max: 10 }),
     }

--- a/src/selectors/search.js
+++ b/src/selectors/search.js
@@ -87,12 +87,19 @@ export function transformTrace(trace) {
     };
   });
 
+  const isErredTag = ({ key, value }) => key === 'error' && value === true;
+  const numberOfErredSpans = trace.spans.reduce(
+    (total, { tags }) => total + Number(tags.some(isErredTag)),
+    0
+  );
+
   return {
     traceName: getTraceName(trace),
     traceID: trace.traceID,
     numberOfSpans: trace.spans.length,
     duration: traceDuration / 1000,
     timestamp: Math.floor(getTraceTimestamp(trace) / 1000),
+    numberOfErredSpans,
     services,
   };
 }

--- a/src/selectors/search.test.js
+++ b/src/selectors/search.test.js
@@ -32,6 +32,16 @@ it('transformTrace() works accurately', () => {
   expect(transformedTrace.duration).toBe(trace.duration / 1000);
 
   expect(transformedTrace.timestamp).toBe(Math.floor(trace.timestamp / 1000));
+
+  const erredTag = { key: 'error', type: 'bool', value: true };
+
+  expect(transformedTrace.numberOfErredSpans).toBe(0);
+
+  trace.spans[0].tags.push(erredTag);
+  expect(searchSelectors.transformTrace(trace).numberOfErredSpans).toBe(1);
+
+  trace.spans[1].tags.push(erredTag);
+  expect(searchSelectors.transformTrace(trace).numberOfErredSpans).toBe(2);
 });
 
 it('transformTraceResults() calculates the max duration of all traces', () => {


### PR DESCRIPTION
Adds text stating number of spans with errors in trace search results. Text is omitted when the trace does not contain any erred spans. Not sure about the color, used `#c00`.

Full page:

![_jaeger_ui_005-0](https://cloud.githubusercontent.com/assets/2304337/26022207/836e7da4-376c-11e7-8415-e1416481bf53.png)

Detail:
<img width="675" alt="_jaeger_ui_005-1" src="https://cloud.githubusercontent.com/assets/2304337/26022206/836cc806-376c-11e7-9015-7513257ac0c5.png">
