### PR TITLE
Fixes #12 - TraceView header expander not working correctly

### DIFF
--- a/src/components/TracePage/TraceTimelineViewer/utils.test.js
+++ b/src/components/TracePage/TraceTimelineViewer/utils.test.js
@@ -18,8 +18,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import { spanContainsErredSpan } from './utils';
+import {
+  isClientSpan,
+  isErrorSpan,
+  isServerSpan,
+  spanContainsErredSpan,
+} from './utils';
 import traceGenerator from '../../../demo/trace-generators';
+
+it('isClientSpan(...) is true only when a span.kind=client tag is present', () => {
+  const tags = traceGenerator.tags();
+  expect(isClientSpan({ tags })).toBe(false);
+  tags.push({ key: 'span.kind', value: 'client' });
+  expect(isClientSpan({ tags })).toBe(true);
+});
+
+it('isServerSpan(...) is true only when a span.kind=server tag is present', () => {
+  const tags = traceGenerator.tags();
+  expect(isServerSpan({ tags })).toBe(false);
+  tags.push({ key: 'span.kind', value: 'server' });
+  expect(isServerSpan({ tags })).toBe(true);
+});
+
+it('isErrorSpan(...) is true only when a error=true tag is present', () => {
+  const tags = traceGenerator.tags();
+  expect(isErrorSpan({ tags })).toBe(false);
+  tags.push({ key: 'error', value: true });
+  expect(isErrorSpan({ tags })).toBe(true);
+});
 
 it('spanContainsErredSpan(...) is true only when a descendant has an error tag', () => {
   const errorTag = { key: 'error', type: 'bool', value: true };

--- a/src/components/TracePage/index.js
+++ b/src/components/TracePage/index.js
@@ -121,6 +121,7 @@ export default class TracePage extends Component {
   toggleSlimView(slimView) {
     this.setState({ slimView });
     // fix issue #12 - TraceView header expander not working correctly
+    // TODO: evaluate alternatives to react-sticky
     setTimeout(() => this.forceUpdate(), 0);
   }
 

--- a/src/components/TracePage/index.js
+++ b/src/components/TracePage/index.js
@@ -120,6 +120,8 @@ export default class TracePage extends Component {
 
   toggleSlimView(slimView) {
     this.setState({ slimView });
+    // fix issue #12 - TraceView header expander not working correctly
+    setTimeout(() => this.forceUpdate(), 0);
   }
 
   ensureTraceFetched() {


### PR DESCRIPTION
This fixes #12, but it is a hack—`setTimeout()` with `forceUpdate()` are used to ensure the `<Sticky />` component has the latest dimensions of its content when calculating its layout.

IMO, a better long-term fix is to remove `react-sticky`. Using `position: fixed`, directly, should suffice because the elements that need to be "sticky" are flush with the top at all times and therefore can just be position fixed.

Note: I wrapped the `<Sticky />` element with a `<StickyContainer />`, per [the intended use of `react-sticky`](https://github.com/captivationsoftware/react-sticky/blob/master/examples/basic/basic.js#L25), but that did not resolve the issue.