### PR TITLE
Fix #43 - Search page UI responsiveness sluggish when many spans in results

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,15 @@
 {
   "extends": [
-    "react-app", 
-    "airbnb", 
-    "prettier", 
-    "prettier/flowtype", 
+    "react-app",
+    "airbnb",
+    "prettier",
+    "prettier/flowtype",
     "prettier/react"
   ],
   "rules": {
     /* general */
     "comma-dangle": 0,
-    "arrow-parens": 1,
+    "arrow-parens": [1, "as-needed"],
     "no-restricted-syntax": 0,
     "no-plusplus": 0,
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,9 @@
 {
+  "env": {
+    "browser": true,
+    "jest": true,
+    "jasmine": true
+  },
   "extends": [
     "react-app",
     "airbnb",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint-plugin-flowtype": "^2.21.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.4.1",
+    "eslint-plugin-react": "7.1.0",
     "husky": "^0.13.3",
     "lint-staged": "^3.4.0",
     "react-scripts": "^0.9.5",

--- a/src/utils/get-last-xform-cacher.js
+++ b/src/utils/get-last-xform-cacher.js
@@ -26,9 +26,9 @@
  *
  * @param  {function} xformer The transformer function, the most recent result
  *                            of which is cached.
- * @return {function} A wrapper around the transformer function which which
- *                    caches the last transformation, returning the cached
- *                    value if the source value is the same.
+ * @return {function} A wrapper around the transformer function which caches
+ *                    the last transformation, returning the cached value if
+ *                    the source value is the same.
  */
 export default function getLastXformCacher(xformer) {
   let lastArgs = null;

--- a/src/utils/get-last-xform-cacher.js
+++ b/src/utils/get-last-xform-cacher.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/**
+ * Given a transformer function, returns a function that invokes the
+ * transformer on the argument and caches the transformation before returning
+ * it. If the source value changes, the transformation is recalculated, cached
+ * and returned.
+ *
+ * @param  {function} xformer The transformer function, the most recent result
+ *                            of which is cached.
+ * @return {function} A wrapper around the transformer function which which
+ *                    caches the last transformation, returning the cached
+ *                    value if the source value is the same.
+ */
+export default function getLastXformCacher(xformer) {
+  let lastArgs = null;
+  let lastXformed = null;
+
+  return function getOrCache(...args) {
+    const sameArgs = lastArgs &&
+      lastArgs.length === args.length &&
+      lastArgs.every((lastArg, i) => lastArg === args[i]);
+    if (sameArgs) {
+      return lastXformed;
+    }
+    lastArgs = args;
+    lastXformed = xformer(...args);
+    return lastXformed;
+  };
+}

--- a/src/utils/get-last-xform-cacher.test.js
+++ b/src/utils/get-last-xform-cacher.test.js
@@ -1,0 +1,89 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import getLastXformCacher from './get-last-xform-cacher';
+
+const xformImpl = value => value + value;
+let xformer;
+let cacher;
+
+beforeEach(() => {
+  xformer = jest.fn(xformImpl);
+  cacher = getLastXformCacher(xformer);
+});
+
+it('returns a function', () => {
+  expect(cacher).toEqual(jasmine.any(Function));
+});
+
+it('handles the first invocation where nothing is cached', () => {
+  expect(() => cacher('a')).not.toThrow();
+});
+
+it('the returned function returns the same results as the transformer function', () => {
+  expect(cacher('a')).toBe(xformImpl('a'));
+  expect(cacher('a')).toBe(xformImpl('a'));
+  expect(cacher(1)).toBe(xformImpl(1));
+  expect(cacher('a')).not.toBe(cacher('b'));
+});
+
+it('the returned function returns a cached value for subsequent invocation with the same argument', () => {
+  expect(xformer.mock.calls.length).toBe(0);
+  const value = cacher('a');
+  expect(xformer.mock.calls.length).toBe(1);
+  expect(cacher('a')).toBe(value);
+  expect(xformer.mock.calls.length).toBe(1);
+});
+
+it('the returned function ignores the cached value when invoked with different arguments', () => {
+  expect(xformer.mock.calls.length).toBe(0);
+  const firstValue = cacher('a');
+  expect(xformer.mock.calls.length).toBe(1);
+  expect(cacher('a')).toBe(firstValue);
+  expect(xformer.mock.calls.length).toBe(1);
+  const secondValue = cacher('b');
+  expect(xformer.mock.calls.length).toBe(2);
+  expect(cacher('b')).toBe(secondValue);
+  expect(xformer.mock.calls.length).toBe(2);
+});
+
+it('the functionality works with multiple arguments', () => {
+  const multiXformer = jest.fn((a, b) => [a + a, b + b]);
+  const multiCacher = getLastXformCacher(multiXformer);
+
+  expect(multiXformer.mock.calls.length).toBe(0);
+  const firstValue = multiCacher('a', 'b');
+
+  expect(multiXformer.mock.calls.length).toBe(1);
+  expect(firstValue).toEqual(['aa', 'bb']);
+  expect(multiCacher('a', 'b')).toBe(firstValue);
+  expect(multiXformer.mock.calls.length).toBe(1);
+
+  const secondValue = multiCacher('A', 'B');
+  expect(multiXformer.mock.calls.length).toBe(2);
+  expect(secondValue).toEqual(['AA', 'BB']);
+  expect(multiCacher('A', 'B')).toBe(secondValue);
+  expect(multiXformer.mock.calls.length).toBe(2);
+
+  const thirdValue = multiCacher('A', 'B', 'extra-arg');
+  expect(multiXformer.mock.calls.length).toBe(3);
+  expect(thirdValue).not.toBe(secondValue);
+  expect(thirdValue).toEqual(secondValue);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,7 +1874,7 @@ doctrine@1.5.0:
 
 doctrine@^2.0.0:
   version "2.0.0"
-  resolved "https://unpm.uberinternal.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
@@ -2238,7 +2238,7 @@ eslint-plugin-react@6.4.1:
 
 eslint-plugin-react@7.1.0:
   version "7.1.0"
-  resolved "https://unpm.uberinternal.com/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz#27770acf39f5fd49cd0af4083ce58104eb390d4c"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz#27770acf39f5fd49cd0af4083ce58104eb390d4c"
   dependencies:
     doctrine "^2.0.0"
     has "^1.0.1"
@@ -3729,7 +3729,7 @@ jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.1:
 
 jsx-ast-utils@^1.4.1:
   version "1.4.1"
-  resolved "https://unpm.uberinternal.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
 kind-of@^3.0.2:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,6 +1872,13 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+doctrine@^2.0.0:
+  version "2.0.0"
+  resolved "https://unpm.uberinternal.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
 dom-converter@~0.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
@@ -2222,12 +2229,20 @@ eslint-plugin-jsx-a11y@4.0.0, eslint-plugin-jsx-a11y@^4.0.0:
     jsx-ast-utils "^1.0.0"
     object-assign "^4.0.1"
 
-eslint-plugin-react@6.4.1, eslint-plugin-react@^6.4.1:
+eslint-plugin-react@6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.4.1.tgz#7d1aade747db15892f71eee1fea4addf97bcfa2b"
   dependencies:
     doctrine "^1.2.2"
     jsx-ast-utils "^1.3.1"
+
+eslint-plugin-react@7.1.0:
+  version "7.1.0"
+  resolved "https://unpm.uberinternal.com/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz#27770acf39f5fd49cd0af4083ce58104eb390d4c"
+  dependencies:
+    doctrine "^2.0.0"
+    has "^1.0.1"
+    jsx-ast-utils "^1.4.1"
 
 eslint@3.16.1, eslint@^3.16.1:
   version "3.16.1"
@@ -3711,6 +3726,10 @@ jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz#5afe38868f56bc8cc7aeaef0100ba8c75bd12591"
   dependencies:
     object-assign "^4.1.0"
+
+jsx-ast-utils@^1.4.1:
+  version "1.4.1"
+  resolved "https://unpm.uberinternal.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
 kind-of@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
Fix #43

Fix an issue with the search page that shows up when there are many spans (cumulatively) in the search results. Issue at hand is the `mapStateToProps` function calls `.toJS()` on some of the immutableJS state values, transforms the resultant values, then passes the transformed values to reselect. The `.toJS()` invocation prevents the calculations from being memoized by reselect because it always results in new objects or arrays.

The change is to wrap the `.toJS()` call and subsequent transformation in a function, the result of which is cached based on the state value. The caching resolves the issue. Only the last result needs to be cached because these are top-level state values (vs transforming items in an array) and therefore a state value will never be revisited.