### PR TITLE
Fix traceIDs query params clobbering form search

### DIFF
--- a/src/components/SearchTracePage/TraceSearchForm.js
+++ b/src/components/SearchTracePage/TraceSearchForm.js
@@ -285,8 +285,8 @@ const mapDispatchToProps = dispatch => {
         minDuration,
         maxDuration,
         lookback,
-        traceIDs,
       } = fields;
+      // Note: traceID is ignored when the form is submitted
 
       store.set('lastSearch', { service, operation });
 
@@ -317,7 +317,6 @@ const mapDispatchToProps = dispatch => {
         tag: tagsToQuery(tags) || undefined,
         minDuration: minDuration || null,
         maxDuration: maxDuration || null,
-        traceID: traceIDsToQuery(traceIDs) || undefined,
       });
     },
   };


### PR DESCRIPTION
Fix #82.

Changed functionality is: traceIDs are ignored when the search form is triggering the search.